### PR TITLE
Implement services and dev village provider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,8 @@ module.exports = {
     '!**/node_modules/**',
     '!src/index.tsx',
     '!src/types/**',
+    '!types.ts',
+    '!src/provider/Village/Dev/index.ts',
   ],
   coverageThreshold: {
     'src/**/*.{js,jsx,ts,tsx}': {

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
-import { Provider } from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
 
 import store from '../../store';
-
 import Layout from '../Layout';
+import {
+  VillageServiceContextProvider,
+  initVillageServiceContext,
+} from '../../context/VillageService';
 
 import './reset.scss';
 import './styles.scss';
 
 export const App = (): JSX.Element => (
-  <Provider store={store}>
-    <Layout />
-  </Provider>
+  <VillageServiceContextProvider value={initVillageServiceContext()}>
+    <ReduxProvider store={store}>
+      <Layout />
+    </ReduxProvider>
+  </VillageServiceContextProvider>
 );
 
 export default App;

--- a/src/components/Views/Controller/Desktop/index.test.tsx
+++ b/src/components/Views/Controller/Desktop/index.test.tsx
@@ -4,10 +4,14 @@ import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 
 import { DesktopViewController } from '.';
+import { PHASE_NAME } from '../../../../types/phase';
 
 // Mock the views with testids
 jest.mock('../../Desktop/NoPhase', () => (): JSX.Element => (
   <div data-testid='views-desktop-nophase' />
+));
+jest.mock('../../Desktop/Lobby', () => (): JSX.Element => (
+  <div data-testid='views-desktop-lobby' />
 ));
 
 describe('<DesktopViewController>', () => {
@@ -16,6 +20,14 @@ describe('<DesktopViewController>', () => {
       const result = render(<DesktopViewController />);
 
       expect(result.getByTestId('views-desktop-nophase')).toBeInTheDocument();
+    });
+
+    it('with lobby phase', () => {
+      const result = render(
+        <DesktopViewController phaseName={PHASE_NAME.LOBBY} />
+      );
+
+      expect(result.getByTestId('views-desktop-lobby')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Views/Controller/Desktop/index.tsx
+++ b/src/components/Views/Controller/Desktop/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import DesktopNoPhaseView from '../../Desktop/NoPhase';
+import DesktopLobbyView from '../../Desktop/Lobby';
+import { PHASE_NAME } from '../../../../types/phase';
 
 interface IProps {
   phaseName?: string;
@@ -8,14 +10,10 @@ interface IProps {
 
 export const DesktopViewController = (props: IProps): JSX.Element => {
   switch (props.phaseName) {
+    case PHASE_NAME.LOBBY:
+      return <DesktopLobbyView />;
     default:
-      return (
-        // eslint disable temporary until connected up to dispatch
-        <DesktopNoPhaseView
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-          onCreateVillageClick={(_villageName: string): void => {}}
-        />
-      );
+      return <DesktopNoPhaseView />;
   }
 };
 

--- a/src/components/Views/Controller/Mobile/index.test.tsx
+++ b/src/components/Views/Controller/Mobile/index.test.tsx
@@ -4,10 +4,14 @@ import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 
 import { MobileViewController } from '.';
+import { PHASE_NAME } from '../../../../types/phase';
 
 // Mock the views with testids
 jest.mock('../../Mobile/NoPhase', () => (): JSX.Element => (
   <div data-testid='views-mobile-nophase' />
+));
+jest.mock('../../Mobile/Lobby', () => (): JSX.Element => (
+  <div data-testid='views-mobile-lobby' />
 ));
 
 describe('<MobileViewController>', () => {
@@ -16,6 +20,14 @@ describe('<MobileViewController>', () => {
       const result = render(<MobileViewController />);
 
       expect(result.getByTestId('views-mobile-nophase')).toBeInTheDocument();
+    });
+
+    it('with lobby phase', () => {
+      const result = render(
+        <MobileViewController phaseName={PHASE_NAME.LOBBY} />
+      );
+
+      expect(result.getByTestId('views-mobile-lobby')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Views/Controller/Mobile/index.tsx
+++ b/src/components/Views/Controller/Mobile/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import MobileNoPhaseView from '../../Mobile/NoPhase';
+import MobileLobbyView from '../../Mobile/Lobby';
+import { PHASE_NAME } from '../../../../types/phase';
 
 interface IProps {
   phaseName?: string;
@@ -8,19 +10,10 @@ interface IProps {
 
 export const MobileViewController = (props: IProps): JSX.Element => {
   switch (props.phaseName) {
+    case PHASE_NAME.LOBBY:
+      return <MobileLobbyView />;
     default:
-      return (
-        // eslint disable temporary until connected up to dispatch
-        <MobileNoPhaseView
-          onJoinVillageClick={(
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            _playerName: string,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            _gameCode: string
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-          ): void => {}}
-        />
-      );
+      return <MobileNoPhaseView />;
   }
 };
 

--- a/src/components/Views/Desktop/Lobby/index.test.tsx
+++ b/src/components/Views/Desktop/Lobby/index.test.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+import { DesktopLobbyView } from '.';
+
+describe('<DesktopLobbyView>', () => {
+  it('renders as expected', () => {
+    const result = render(<DesktopLobbyView />);
+
+    expect(result.getByText('Desktop Lobby')).toBeInTheDocument();
+  });
+});

--- a/src/components/Views/Desktop/Lobby/index.tsx
+++ b/src/components/Views/Desktop/Lobby/index.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const DesktopLobbyView = (): JSX.Element => <p>Desktop Lobby</p>;
+
+export default DesktopLobbyView;

--- a/src/components/Views/Desktop/NoPhase/index.test.tsx
+++ b/src/components/Views/Desktop/NoPhase/index.test.tsx
@@ -1,15 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 
 import { DesktopNoPhaseView } from '.';
+import { VillageServiceContextProvider } from '../../../../context/VillageService';
 
 describe('<DesktopNoPhaseView>', () => {
   it('renders as expected', () => {
-    const mockOnClick = jest.fn();
-    const result = render(
-      <DesktopNoPhaseView onCreateVillageClick={mockOnClick} />
-    );
+    const result = render(<DesktopNoPhaseView />);
 
     const input = result.getByPlaceholderText('Village Name');
     expect(input).toBeInTheDocument();
@@ -19,9 +18,14 @@ describe('<DesktopNoPhaseView>', () => {
   });
 
   it('handles create button click correctly', async () => {
-    const mockOnClick = jest.fn();
+    const mockVillageService: any = {
+      createVillage: jest.fn(),
+    };
+
     const result = render(
-      <DesktopNoPhaseView onCreateVillageClick={mockOnClick} />
+      <VillageServiceContextProvider value={mockVillageService}>
+        <DesktopNoPhaseView />
+      </VillageServiceContextProvider>
     );
 
     const input = result.getByPlaceholderText('Village Name');
@@ -32,7 +36,7 @@ describe('<DesktopNoPhaseView>', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
-    expect(mockOnClick).toHaveBeenCalledWith('New');
+    expect(mockVillageService.createVillage).toHaveBeenCalledTimes(1);
+    expect(mockVillageService.createVillage).toHaveBeenCalledWith('New');
   });
 });

--- a/src/components/Views/Desktop/NoPhase/index.tsx
+++ b/src/components/Views/Desktop/NoPhase/index.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
+
 import TextInput from '../../../Input/Text';
 import Button from '../../../Button';
+import { VillageServiceContext } from '../../../../context/VillageService';
 
-interface IProps {
-  onCreateVillageClick: (villageName: string) => void; // will come from redux dispatch connect
-}
-
-export const DesktopNoPhaseView = (props: IProps): JSX.Element => {
+export const DesktopNoPhaseView = (): JSX.Element => {
   const [villageName, setVillageName] = React.useState('');
+  const villageService = React.useContext(VillageServiceContext);
+
+  const onClick = async (): Promise<void> => {
+    await villageService.createVillage(villageName);
+  };
 
   return (
     <React.Fragment>
@@ -16,9 +19,7 @@ export const DesktopNoPhaseView = (props: IProps): JSX.Element => {
         onChange={setVillageName}
         placeholder='Village Name'
       />
-      <Button onClick={(): void => props.onCreateVillageClick(villageName)}>
-        Create Village
-      </Button>
+      <Button onClick={onClick}>Create Village</Button>
     </React.Fragment>
   );
 };

--- a/src/components/Views/Mobile/Lobby/index.test.tsx
+++ b/src/components/Views/Mobile/Lobby/index.test.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+import { MobileLobbyView } from '.';
+
+describe('<MobileLobbyView>', () => {
+  it('renders as expected', () => {
+    const result = render(<MobileLobbyView />);
+
+    expect(result.getByText('Mobile Lobby')).toBeInTheDocument();
+  });
+});

--- a/src/components/Views/Mobile/Lobby/index.tsx
+++ b/src/components/Views/Mobile/Lobby/index.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const MobileLobbyView = (): JSX.Element => <p>Mobile Lobby</p>;
+
+export default MobileLobbyView;

--- a/src/components/Views/Mobile/NoPhase/index.test.tsx
+++ b/src/components/Views/Mobile/NoPhase/index.test.tsx
@@ -1,15 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 
 import { MobileNoPhaseView } from '.';
+import { VillageServiceContextProvider } from '../../../../context/VillageService';
 
 describe('<MobileNoPhaseView>', () => {
   it('renders as expected', () => {
-    const mockOnClick = jest.fn();
-    const result = render(
-      <MobileNoPhaseView onJoinVillageClick={mockOnClick} />
-    );
+    const result = render(<MobileNoPhaseView />);
 
     const nameInput = result.getByPlaceholderText('Player Name');
     expect(nameInput).toBeInTheDocument();
@@ -22,9 +21,14 @@ describe('<MobileNoPhaseView>', () => {
   });
 
   it('handles create button click correctly', async () => {
-    const mockOnClick = jest.fn();
+    const mockVillageService: any = {
+      joinVillage: jest.fn(),
+    };
+
     const result = render(
-      <MobileNoPhaseView onJoinVillageClick={mockOnClick} />
+      <VillageServiceContextProvider value={mockVillageService}>
+        <MobileNoPhaseView />
+      </VillageServiceContextProvider>
     );
 
     const nameInput = result.getByPlaceholderText('Player Name');
@@ -39,7 +43,7 @@ describe('<MobileNoPhaseView>', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
-    expect(mockOnClick).toHaveBeenCalledWith('Dave', '123');
+    expect(mockVillageService.joinVillage).toHaveBeenCalledTimes(1);
+    expect(mockVillageService.joinVillage).toHaveBeenCalledWith('Dave', '123');
   });
 });

--- a/src/components/Views/Mobile/NoPhase/index.tsx
+++ b/src/components/Views/Mobile/NoPhase/index.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import TextInput from '../../../Input/Text';
 import Button from '../../../Button';
+import { VillageServiceContext } from '../../../../context/VillageService';
 
-interface IProps {
-  onJoinVillageClick: (playerName: string, gameCode: string) => void; // will come from redux dispatch connect
-}
-
-export const MobileNoPhaseView = (props: IProps): JSX.Element => {
+export const MobileNoPhaseView = (): JSX.Element => {
   const [playerName, setPlayerName] = React.useState('');
   const [gameCode, setGameCode] = React.useState('');
+  const villageService = React.useContext(VillageServiceContext);
+
+  const onClick = async (): Promise<void> => {
+    await villageService.joinVillage(playerName, gameCode);
+  };
 
   return (
     <React.Fragment>
@@ -22,11 +24,7 @@ export const MobileNoPhaseView = (props: IProps): JSX.Element => {
         onChange={setGameCode}
         placeholder='Game Code'
       />
-      <Button
-        onClick={(): void => props.onJoinVillageClick(playerName, gameCode)}
-      >
-        Join Village
-      </Button>
+      <Button onClick={onClick}>Join Village</Button>
     </React.Fragment>
   );
 };

--- a/src/context/VillageService/index.test.ts
+++ b/src/context/VillageService/index.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { VillageService } from '../../service/Village';
+import { DevVillageProvider } from '../../provider/Village/Dev';
+import { StoreInteractorService } from '../../service/StoreInteractor';
+import store from '../../store';
+
+import { initVillageServiceContext } from '.';
+
+jest.mock('react', () => ({
+  createContext: (): any => ({ Provider: 'provider', Consumer: 'consumer' }),
+}));
+
+// Auto-mock should be fine for these
+jest.mock('../../service/Village');
+jest.mock('../../provider/Village/Dev');
+jest.mock('../../service/StoreInteractor');
+jest.mock('../../store');
+
+describe('VillageServiceContext', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // not going to test React.createContext itself because... it's react
+
+  describe('initVillageServiceContext', () => {
+    it('calls createContext correctly', () => {
+      initVillageServiceContext();
+
+      expect(DevVillageProvider as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(StoreInteractorService as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(StoreInteractorService as jest.Mock).toHaveBeenCalledWith(store);
+      expect(VillageService as jest.Mock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/context/VillageService/index.ts
+++ b/src/context/VillageService/index.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { IVillageService, VillageService } from '../../service/Village';
+import { DevVillageProvider } from '../../provider/Village/Dev';
+import { StoreInteractorService } from '../../service/StoreInteractor';
+import store from '../../store';
+
+export const initVillageServiceContext = (): IVillageService =>
+  new VillageService(
+    new DevVillageProvider(),
+    new StoreInteractorService(store)
+  );
+
+export const VillageServiceContext = React.createContext<IVillageService>(
+  // always set something to shut TypeScript up
+  initVillageServiceContext()
+);
+
+export const VillageServiceContextProvider = VillageServiceContext.Provider;
+export const VillageServiceContextConsumer = VillageServiceContext.Consumer;

--- a/src/provider/Village/Dev/index.ts
+++ b/src/provider/Village/Dev/index.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { IVillageProvider } from '../types';
+import { IGameState } from '../../../store/reducers/game';
+import { PHASE_NAME } from '../../../types/phase';
+import { IPlayer } from '../../../types/player';
+
+/**
+ * This Dev provider is only used for development purposes, whie the
+ * API BE is actually being built or new features are being developed.
+ * Therefore it is not covered by tests, and should not really be reviewed.
+ */
+
+const createGameState = (
+  villageName: string,
+  player?: IPlayer
+): IGameState => ({
+  gameCode: '12test34',
+  phase: {
+    name: PHASE_NAME.LOBBY,
+    data: undefined,
+  },
+  players: player ? [player] : [],
+  villageName,
+});
+
+export class DevVillageProvider implements IVillageProvider {
+  async createVillage(
+    villageName: string,
+    _userId: string
+  ): Promise<IGameState> {
+    return new Promise((resolve) => {
+      resolve(createGameState(villageName));
+    });
+  }
+
+  async joinVillage(
+    playerName: string,
+    _gameCode: string,
+    _userId: string
+  ): Promise<IGameState> {
+    return new Promise((resolve) => {
+      resolve(
+        createGameState('Some Dev Village', {
+          id: 'someDevPlayerId',
+          name: playerName,
+        })
+      );
+    });
+  }
+}

--- a/src/provider/Village/types.ts
+++ b/src/provider/Village/types.ts
@@ -1,0 +1,10 @@
+import { IGameState } from '../../store/reducers/game';
+
+export interface IVillageProvider {
+  createVillage: (villageName: string, userId: string) => Promise<IGameState>;
+  joinVillage: (
+    playerName: string,
+    gameCode: string,
+    userId: string
+  ) => Promise<IGameState>;
+}

--- a/src/service/StoreInteractor/index.test.ts
+++ b/src/service/StoreInteractor/index.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { initGame } from '../../store/actions/game';
+import { StoreInteractorService } from '.';
+
+jest.mock('../../store/actions/game', () => ({
+  initGame: jest.fn(() => 'initGameReturn'),
+}));
+
+describe('StoreInteractorService', () => {
+  const mockStore: any = {
+    dispatch: jest.fn(),
+    getState: (): any => ({ user: { id: 'testUserId' } }),
+  };
+  const mockGame: any = {
+    some: 'game-state',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('constructs ok', () => {
+    const service = new StoreInteractorService(mockStore);
+    expect(service).toBeInstanceOf(StoreInteractorService);
+  });
+
+  describe('initGame', () => {
+    it('returns as expected', () => {
+      const service = new StoreInteractorService(mockStore);
+
+      service.initGame(mockGame);
+
+      expect(initGame as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(initGame as jest.Mock).toHaveBeenCalledWith(mockGame);
+      expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+      expect(mockStore.dispatch).toHaveBeenCalledWith('initGameReturn');
+    });
+  });
+
+  describe('getUserId', () => {
+    it('returns as expected', () => {
+      const service = new StoreInteractorService(mockStore);
+
+      expect(service.getUserId()).toBe('testUserId');
+    });
+  });
+});

--- a/src/service/StoreInteractor/index.ts
+++ b/src/service/StoreInteractor/index.ts
@@ -1,0 +1,27 @@
+import { Store } from 'redux';
+
+import { IState } from '../../store/reducers';
+import { IGameState } from '../../store/reducers/game';
+import { initGame } from '../../store/actions/game';
+import { IAction } from '../../store/actions/types';
+
+export interface IStoreInteractorService {
+  initGame: (gameState: IGameState) => void;
+  getUserId: () => string;
+}
+
+export class StoreInteractorService implements IStoreInteractorService {
+  store: Store<IState, IAction>;
+
+  constructor(store: Store<IState, IAction>) {
+    this.store = store;
+  }
+
+  initGame(gameState: IGameState): void {
+    this.store.dispatch(initGame(gameState));
+  }
+
+  getUserId(): string {
+    return this.store.getState().user.id;
+  }
+}

--- a/src/service/Village/index.test.ts
+++ b/src/service/Village/index.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { logError } from '../../utils/logger';
+import { VillageService } from '.';
+
+jest.mock('../../store/actions/game', () => ({
+  initGame: jest.fn(() => 'initGameReturn'),
+}));
+jest.mock('../../utils/logger');
+
+describe('VillageService', () => {
+  const mockProvider: any = {
+    createVillage: jest.fn(
+      () => new Promise((resolve) => resolve('create-village-return'))
+    ),
+    joinVillage: jest.fn(
+      () => new Promise((resolve) => resolve('join-village-return'))
+    ),
+  };
+  const mockInteractor: any = {
+    initGame: jest.fn(),
+    getUserId: jest.fn(() => 'test-user-id'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('constructs ok', () => {
+    const service = new VillageService(mockProvider, mockInteractor);
+    expect(service).toBeInstanceOf(VillageService);
+  });
+
+  describe('createVillage', () => {
+    it('requests store initGame correctly', async () => {
+      const service = new VillageService(mockProvider, mockInteractor);
+
+      await service.createVillage('test village');
+
+      expect(mockInteractor.getUserId).toHaveBeenCalledTimes(1);
+      expect(mockProvider.createVillage).toHaveBeenCalledTimes(1);
+      expect(mockProvider.createVillage).toHaveBeenCalledWith(
+        'test village',
+        'test-user-id'
+      );
+      expect(mockInteractor.initGame).toHaveBeenCalledTimes(1);
+      expect(mockInteractor.initGame).toHaveBeenCalledWith(
+        'create-village-return'
+      );
+    });
+
+    it('handles provider error correctly', async () => {
+      const error = new Error('Oh no!');
+      mockProvider.createVillage.mockImplementationOnce(() => {
+        throw error;
+      });
+      const service = new VillageService(mockProvider, mockInteractor);
+
+      await service.createVillage('this should throw');
+
+      expect(logError as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(logError as jest.Mock).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('joinVillage', () => {
+    it('requests store initGame correctly', async () => {
+      const service = new VillageService(mockProvider, mockInteractor);
+
+      await service.joinVillage('test player', '12code34');
+
+      expect(mockInteractor.getUserId).toHaveBeenCalledTimes(1);
+      expect(mockProvider.joinVillage).toHaveBeenCalledTimes(1);
+      expect(mockProvider.joinVillage).toHaveBeenCalledWith(
+        'test player',
+        '12code34',
+        'test-user-id'
+      );
+      expect(mockInteractor.initGame).toHaveBeenCalledTimes(1);
+      expect(mockInteractor.initGame).toHaveBeenCalledWith(
+        'join-village-return'
+      );
+    });
+
+    it('handles provider error correctly', async () => {
+      const error = new Error('Oh no!');
+      mockProvider.joinVillage.mockImplementationOnce(() => {
+        throw error;
+      });
+      const service = new VillageService(mockProvider, mockInteractor);
+
+      await service.joinVillage('throw', 'please');
+
+      expect(logError as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(logError as jest.Mock).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/src/service/Village/index.ts
+++ b/src/service/Village/index.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { IVillageProvider } from '../../provider/Village/types';
+import { IStoreInteractorService } from '../StoreInteractor';
+import { logError } from '../../utils/logger';
+
+export interface IVillageService {
+  createVillage: (villageName: string) => Promise<void>;
+  joinVillage: (playerName: string, gameCode: string) => Promise<void>;
+}
+
+export class VillageService implements IVillageService {
+  villageProvider: IVillageProvider;
+  storeInteractor: IStoreInteractorService;
+
+  constructor(
+    villageProvider: IVillageProvider,
+    storeInteractor: IStoreInteractorService
+  ) {
+    this.villageProvider = villageProvider;
+    this.storeInteractor = storeInteractor;
+  }
+
+  async createVillage(villageName: string): Promise<void> {
+    try {
+      this.storeInteractor.initGame(
+        await this.villageProvider.createVillage(
+          villageName,
+          this.storeInteractor.getUserId()
+        )
+      );
+    } catch (error) {
+      this.onError(error);
+    }
+  }
+
+  async joinVillage(playerName: string, gameCode: string): Promise<void> {
+    try {
+      this.storeInteractor.initGame(
+        await this.villageProvider.joinVillage(
+          playerName,
+          gameCode,
+          this.storeInteractor.getUserId()
+        )
+      );
+    } catch (error) {
+      this.onError(error);
+    }
+  }
+
+  private onError(error: Error): void {
+    logError(error);
+  }
+}

--- a/src/store/actions/game/index.test.ts
+++ b/src/store/actions/game/index.test.ts
@@ -1,0 +1,24 @@
+import { IGameState } from '../../reducers/game';
+import { PHASE_NAME } from '../../../types/phase';
+import { initGame, GAME_ACTION_TYPES } from '.';
+
+describe('Game Actions', () => {
+  describe('initGame', () => {
+    const mockGameState: IGameState = {
+      gameCode: '12test34',
+      phase: {
+        name: PHASE_NAME.LOBBY,
+        data: undefined,
+      },
+      players: [],
+      villageName: 'test village',
+    };
+
+    it('returns as expected', () => {
+      expect(initGame(mockGameState)).toEqual({
+        type: GAME_ACTION_TYPES.INIT_GAME,
+        payload: { ...mockGameState },
+      });
+    });
+  });
+});

--- a/src/store/actions/game/index.ts
+++ b/src/store/actions/game/index.ts
@@ -1,0 +1,13 @@
+import { IGameState } from '../../reducers/game';
+import { IAction } from '../types';
+
+export enum GAME_ACTION_TYPES {
+  INIT_GAME = 'GAME-INIT_GAME',
+}
+
+export type TInitGameAction = IAction<IGameState>;
+
+export const initGame = (gameState: IGameState): TInitGameAction => ({
+  type: GAME_ACTION_TYPES.INIT_GAME,
+  payload: { ...gameState },
+});

--- a/src/store/actions/types.ts
+++ b/src/store/actions/types.ts
@@ -1,0 +1,5 @@
+import { Action } from 'redux';
+
+export interface IAction<T = unknown> extends Action {
+  payload: T;
+}

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -9,6 +9,9 @@ jest.mock('./reducers', () => 'rootReducer');
 describe('store', () => {
   it('inits correctly', () => {
     expect(createStore as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(createStore as jest.Mock).toHaveBeenCalledWith('rootReducer');
+    expect(createStore as jest.Mock).toHaveBeenCalledWith(
+      'rootReducer',
+      undefined // Redux devtools
+    );
   });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { createStore } from 'redux';
-import rootReducer from './reducers';
+import rootReducer, { IState } from './reducers';
+import { IAction } from './actions/types';
 
-export const store = createStore(rootReducer);
+export const store = createStore<IState, IAction, unknown, unknown>(
+  rootReducer,
+  // Enable Redux Devtools
+  (window as any).__REDUX_DEVTOOLS_EXTENSION__ &&
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__()
+);
 
 export default store;

--- a/src/store/reducers/game/index.test.ts
+++ b/src/store/reducers/game/index.test.ts
@@ -1,26 +1,40 @@
-import gameReducer, { IGameState } from '.';
 import { PHASE_NAME } from '../../../types/phase';
+import { GAME_ACTION_TYPES, TInitGameAction } from '../../actions/game';
+import gameReducer, { IGameState } from '.';
 
 describe('store > reducers > game', () => {
+  const mockGameState: IGameState = {
+    gameCode: '123',
+    villageName: 'Test Village',
+    players: [],
+    phase: {
+      name: PHASE_NAME.LOBBY,
+      data: undefined,
+    },
+  };
   describe('with an unknown action', () => {
-    const action = { type: 'UNKNOWN' };
+    const action = { type: 'UNKNOWN', payload: undefined };
 
     it('has no effect on null state', () => {
       expect(gameReducer(null, action)).toBeNull();
     });
 
     it('has no effect on non-null state', () => {
-      const state: IGameState = {
-        gameCode: '123',
-        villageName: 'Test Village',
-        players: [],
-        phase: {
-          name: PHASE_NAME.LOBBY,
-          data: undefined,
-        },
-      };
+      expect(gameReducer(mockGameState, action)).toEqual(mockGameState);
+    });
+  });
 
-      expect(gameReducer(state, action)).toEqual(state);
+  describe(`with ${GAME_ACTION_TYPES.INIT_GAME} action`, () => {
+    const mockAction: TInitGameAction = {
+      type: GAME_ACTION_TYPES.INIT_GAME,
+      payload: { ...mockGameState, villageName: 'Another Village' },
+    };
+    it('inits new game on null state', () => {
+      expect(gameReducer(null, mockAction)).toEqual(mockAction.payload);
+    });
+
+    it('does not overwrite existing game state', () => {
+      expect(gameReducer(mockGameState, mockAction)).toEqual(mockGameState);
     });
   });
 });

--- a/src/store/reducers/game/index.ts
+++ b/src/store/reducers/game/index.ts
@@ -1,6 +1,7 @@
-import { Action } from 'redux';
 import { IPlayer } from '../../../types/player';
 import { TPhases } from '../../../types/phase';
+import { GAME_ACTION_TYPES, TInitGameAction } from '../../actions/game';
+import { IAction } from '../../actions/types';
 
 export interface IGameState {
   gameCode: string; // the game join code used
@@ -12,9 +13,11 @@ export interface IGameState {
 
 export const gameReducer = (
   state: IGameState | null = null, // possibly null, as game is not present before joining
-  action: Action
+  action: IAction
 ): IGameState | null => {
   switch (action.type) {
+    case GAME_ACTION_TYPES.INIT_GAME:
+      return state ? state : { ...(action as TInitGameAction).payload };
     default:
       return state;
   }

--- a/src/store/reducers/user/index.test.ts
+++ b/src/store/reducers/user/index.test.ts
@@ -6,7 +6,7 @@ jest.mock('uuid', () => ({
 
 describe('store > reducers > user', () => {
   describe('initial state', () => {
-    const action = { type: 'UNKNOWN' };
+    const action = { type: 'UNKNOWN', payload: undefined };
 
     afterEach(() => {
       window.localStorage.removeItem('userId');
@@ -26,7 +26,7 @@ describe('store > reducers > user', () => {
   });
 
   describe('with an unknown action', () => {
-    const action = { type: 'UNKNOWN' };
+    const action = { type: 'UNKNOWN', payload: undefined };
     const state: IUserState = {
       id: '123',
     };

--- a/src/store/reducers/user/index.ts
+++ b/src/store/reducers/user/index.ts
@@ -1,5 +1,6 @@
-import { Action } from 'redux';
 import { v4 as uuidv4 } from 'uuid';
+
+import { IAction } from '../../actions/types';
 
 export interface IUserState {
   id: string; // generated and stored in localStorage, will be a guid - specific to each device. Used to identify user to the server
@@ -24,7 +25,7 @@ const getInitialState = (): IUserState => ({
 
 export const userReducer = (
   state: IUserState = getInitialState(),
-  action: Action
+  action: IAction
 ): IUserState => {
   switch (action.type) {
     default:

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -1,11 +1,11 @@
-enum PLAYER_ROLE {
+export enum PLAYER_ROLE {
   UNKNOWN = 'UNKNOWN',
   VILLAGER = 'VILLAGER',
   SEER = 'SEER',
   WEREWOLF = 'WEREWOLF',
 }
 
-enum PLAYER_TEAM {
+export enum PLAYER_TEAM {
   UNKNOWN = 'UNKNOWN',
   GOOD = 'GOOD',
   EVIL = 'EVIL',


### PR DESCRIPTION
## ✅ What & Why

This application will eventually have to react (hah) with a backend. For that we use the service/provider pattern, whereby the service is the layer exposed to the rest of the application to request data, and the provider is what the service uses to get that data. That allows the separating out of code concerned with actually interfacing with an API/socket/whatever, and the thing exposed to the app, handling any conversion.

In this PR is a "Dev" provider which will be used until a BE exists to actually integrate with. Don't bother reviewing it - there's a comment to that effect.

I've decided to not use the whole Redux-middleware-dispatch-intercept pattern, because frankly it adds so much boilerplate for very little gain. With just the simple serivce/provider pattern (and a separate store interaction service) we can get exactly the same bang-for-buck without the extra overhead of worrying about middleware and all that bullshit.

<!--- High level description of changes. Highlight expectations for code review. --->
